### PR TITLE
Support template in file name

### DIFF
--- a/lib/scaffold.js
+++ b/lib/scaffold.js
@@ -79,6 +79,10 @@ module.exports = function(dirIn, dirOut, options, callback) {
           // Otherwise, we need to run this file through the templating engine.
           else {
             dest = dest.replace('.' + options.ext, '');
+            dest_tpl = dest.match(/\{\{(.*)\}\}/);
+            if(dest_tpl && dest_tpl[0] && options.data[dest_tpl[1]]) {
+              dest = dest.replace(dest_tpl[0], options.data[dest_tpl[1]]);
+            }
             cons[options.engine](file, options.data, function(err, templated) {
               if (err) return done(err);
               fs.writeFile(dest, templated, options.encoding, done);

--- a/lib/scaffold.js
+++ b/lib/scaffold.js
@@ -59,9 +59,9 @@ module.exports = function(dirIn, dirOut, options, callback) {
   dive(dirIn, {all: true, directories: true}, function(err, path) {
     var stats = fs.statSync(path);
     if (stats.isDirectory()) {
-      dest_tpl = dirOut.match(/\{\{(.*)\}\}/);
+      dest_tpl = path.match(/\{\{(.*)\}\}/);
       if(dest_tpl && dest_tpl[0] && options.data[dest_tpl[1]]) {
-        dirOut = dirOut.replace(dest_tpl[0], options.data[dest_tpl[1]]);
+        path = path.replace(dest_tpl[0], options.data[dest_tpl[1]]);
       }
       mkdirp.sync(path.replace(dirIn, dirOut));
     }

--- a/lib/scaffold.js
+++ b/lib/scaffold.js
@@ -59,6 +59,10 @@ module.exports = function(dirIn, dirOut, options, callback) {
   dive(dirIn, {all: true, directories: true}, function(err, path) {
     var stats = fs.statSync(path);
     if (stats.isDirectory()) {
+      dest_tpl = dirOut.match(/\{\{(.*)\}\}/);
+      if(dest_tpl && dest_tpl[0] && options.data[dest_tpl[1]]) {
+        dirOut = dirOut.replace(dest_tpl[0], options.data[dest_tpl[1]]);
+      }
       mkdirp.sync(path.replace(dirIn, dirOut));
     }
     else {


### PR DESCRIPTION
To allow creation of '{{var}}.tpl.html' like files, resulting 'foo.html' if var = 'foo'.

Maybe it's could be better to use consolidate for this, but some engine has forbidden characters for filenames to open/close block.
